### PR TITLE
Fix CSP header value in README with correct value

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ There are some differences to the original projects, namely:
 
 Camo allows users to proxy essentially arbitrary files through it. If your application is vulnerable, Camo could be used to bypass cross-origin boundaries for assets. To reduce the risk a bit, `camo-rs` will always set the following headers in all of its proxied responses:
 
-- `content-security-policy: default-src 'none'; img-src data:`
+- `content-security-policy: default-src 'none'; img-src data:; style-src 'unsafe-inline'`
 - `x-content-type-options: nosniff`
 - `x-frame-options: deny`
 - `x-xss-protection: 1; mode=block`


### PR DESCRIPTION
I noticed that the code in [`header_wrangler.rs`](https://github.com/denschub/camo-rs/blob/c524f3a0d3fd04a2be23af3ccf0889a52691d45c/src/header_wrangler.rs#L29) sets a different value than what was written in the readme.