### PR TITLE
Pass the upstream status code towards the client if we see an UnexpectedUpstreamStatus.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # 1.0.0-dev
 
 - `camo-rs` now refuses to start if no content-types are allowed. Before that, Camo would start up just fine, but reject everything, which can be confusing.
+- When receiving a status code outside the expected range (`[200..399]`), Camo will still reject that request, but will pass the upstream status code to the client.
 
 # 0.1.0
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -77,11 +77,11 @@ async fn proxy_handler(
                 warn!("Upstream proxy error: {:?}", err);
                 get_response_with_status_and_text(502, "Upstream connection failed!")
             }
-            CamoError::UnexpectedUpstreamStatus(err) => {
+            CamoError::UnexpectedUpstreamStatus(status_code) => {
                 warn!("Unexpected upstream status: {:?}", err);
                 get_response_with_status_and_text(
-                    502,
-                    &format!("Unexpected upstream status: {}!", err),
+                    status_code,
+                    &format!("Unexpected upstream status: {}!", status_code),
                 )
             }
             CamoError::UpstreamRedirectLocationUnprocessable => {

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -69,11 +69,11 @@ async fn rejects_invalid_targets() {
 }
 
 #[tokio::test]
-async fn rejects_unexpected_status_codes() {
+async fn rejects_but_forwards_unexpected_status_codes() {
     let upstream = get_single_file_mock(418).await;
     let resp = run_valid_upstream_request(&upstream).await.unwrap();
 
-    assert_eq!(resp.status(), 502);
+    assert_eq!(resp.status(), 418);
 }
 
 #[tokio::test]


### PR DESCRIPTION
For example, if we see a `404` upstream, Camo will now return a `404` instead of a `502`.