### PR TITLE
Support JSON 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,5 @@ RUN \
 USER app:app
 COPY --from=builder /app/out/bin/camo /app
 
-EXPOSE 8081
 HEALTHCHECK CMD curl -f http://localhost:8081/__heartbeat__ || exit 1
-CMD ["/app/camo"]
+CMD ["/app/camo", "--log-level", "info"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,6 @@ RUN \
 USER app:app
 COPY --from=builder /app/out/bin/camo /app
 
+EXPOSE 8081
 HEALTHCHECK CMD curl -f http://localhost:8081/__heartbeat__ || exit 1
-CMD ["/app/camo", "--log-level", "info"]
+CMD ["/app/camo"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ At least one `content-type` needs to be allowed, or Camo will refuse to start.
 
 - `--allow-audio` / `CAMO_ALLOW_AUDIO` - Whether `audio/*` MIME types should be allowed. (default: `false`)
 - `--allow-image` / `CAMO_ALLOW_IMAGE` - Whether `image/*` MIME types should be allowed. (default: `false`)
+- `--allow-json` / `CAMO_ALLOW_JSON` - Whether `json/*` MIME types should be allowed. (default: `false`)
 - `--allow-video` / `CAMO_ALLOW_VIDEO` - Whether `video/*` MIME types should be allowed. (default: `false`)
 
 ## Other settings

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ At least one `content-type` needs to be allowed, or Camo will refuse to start.
 
 - `--allow-audio` / `CAMO_ALLOW_AUDIO` - Whether `audio/*` MIME types should be allowed. (default: `false`)
 - `--allow-image` / `CAMO_ALLOW_IMAGE` - Whether `image/*` MIME types should be allowed. (default: `false`)
-- `--allow-json` / `CAMO_ALLOW_JSON` - Whether `json/*` MIME types should be allowed. (default: `false`)
+- `--allow-json` / `CAMO_ALLOW_JSON` - Whether `application/json*` MIME types should be allowed. (default: `false`)
 - `--allow-video` / `CAMO_ALLOW_VIDEO` - Whether `video/*` MIME types should be allowed. (default: `false`)
 
 ## Other settings

--- a/src/bin/camo.rs
+++ b/src/bin/camo.rs
@@ -23,7 +23,7 @@ async fn main() {
         LogFormat::Json => subscriber.json().with_span_list(false).init(),
     }
 
-    if !(settings.allow_audio || settings.allow_image || settings.allow_video) {
+    if !(settings.allow_audio || settings.allow_image || settings.allow_video || settings.allow_json) {
         println!(
             "ERROR: The configuration does not allow any content-type, and it \
             would block all requests. This isn't useful. Exiting."

--- a/src/server.rs
+++ b/src/server.rs
@@ -140,7 +140,7 @@ async fn process_camo_request(
         if let Some(content_type) = maybe_content_type {
             let is_accepted = (settings.allow_audio && content_type.starts_with("audio/"))
                 || (settings.allow_image && content_type.starts_with("image/"))
-                || (settings.allow_json && content_type.starts_with("json/"))
+                || (settings.allow_json && content_type.ends_with("/json"))
                 || (settings.allow_video && content_type.starts_with("video/"));
 
             if !is_accepted {

--- a/src/server.rs
+++ b/src/server.rs
@@ -140,6 +140,7 @@ async fn process_camo_request(
         if let Some(content_type) = maybe_content_type {
             let is_accepted = (settings.allow_audio && content_type.starts_with("audio/"))
                 || (settings.allow_image && content_type.starts_with("image/"))
+                || (settings.allow_json && content_type.starts_with("json/"))
                 || (settings.allow_video && content_type.starts_with("video/"));
 
             if !is_accepted {

--- a/src/server.rs
+++ b/src/server.rs
@@ -140,7 +140,7 @@ async fn process_camo_request(
         if let Some(content_type) = maybe_content_type {
             let is_accepted = (settings.allow_audio && content_type.starts_with("audio/"))
                 || (settings.allow_image && content_type.starts_with("image/"))
-                || (settings.allow_json && content_type.ends_with("/json"))
+                || (settings.allow_json && content_type.starts_with("application/json"))
                 || (settings.allow_video && content_type.starts_with("video/"));
 
             if !is_accepted {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -50,6 +50,10 @@ pub struct Settings {
     #[clap(long = "allow-image", env = "CAMO_ALLOW_IMAGE")]
     pub allow_image: bool,
 
+    /// If present, `json/*` MIME types will be allowed
+    #[clap(long = "allow-json", env = "CAMO_ALLOW_JSON")]
+    pub allow_json: bool,
+
     /// If present, `video/*` MIME types will be allowed
     #[clap(long = "allow-video", env = "CAMO_ALLOW_VIDEO")]
     pub allow_video: bool,

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -11,6 +11,7 @@ pub mod application {
         Settings {
             allow_audio: false,
             allow_image: true,
+            allow_json: false,
             allow_video: false,
             header_via: "camo-rs".to_owned(),
             key: "camo-rs".to_owned(),


### PR DESCRIPTION
Adds support for json endpoints. 
Implemented via submodule in https://github.com/smk762/no_phish_nfts (back end calculates hmac and redirects)
Working example endpoint: https://nft.antispam.dragonhound.info/url_decode/68747470733a2f2f6a736f6e706c616365686f6c6465722e74797069636f64652e636f6d2f746f646f73 (leads to https://jsonplaceholder.typicode.com/todos)

