### PR TITLE
Fix the build-task in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,12 @@ env:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    env:
+      AWS_LC_SYS_CMAKE_BUILDER: true
     steps:
       - uses: actions/checkout@v4
+      - name: Update system
+        run: sudo apt-get update && sudo apt-get install -y cmake
       - name: Update Rust
         run: rustup update stable
       - name: Build release artifacts


### PR DESCRIPTION
[It currently fails](https://github.com/denschub/camo-rs/actions/runs/9232954598/job/25404800994#step:4:226) because the GCC version is too old. Ideally, we'd just update to Ubuntu 22 or 24, but previous attempts failed as it conflicted with other people's too old glibc version 🙃 